### PR TITLE
KP-7713 Fix wonky LBR message templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,7 @@ the first run to completely reinstall wordpress.  "clean=true" wipes
 the whole /var/www/html directory. This might be overkill in some
 situations.
 
- - `cd servers/portal`
- - `ansible-playbook -i inventories/openstack_portal_pre_prod portalPouta.yml --extra-vars clean=true`
+`ansible-playbook -i inventories/openstack_portal_pre_prod portalPouta.yml --extra-vars clean=true`
 
 ## Optional: Resync content between present production and pre-production
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Clone this repository and navigate to the correct directory.
 
 ## Source your cPouta (OpenStack) auth file.
 
-The [OpenStack auth file](https://docs.csc.fi/#cloud/pouta/install-client/#configure-your-terminal-environment-for-openstack) is necessary for provisioning the OpenStack resources. 
+The [OpenStack auth file](https://docs.csc.fi/#cloud/pouta/install-client/#configure-your-terminal-environment-for-openstack) is necessary for provisioning the OpenStack resources.
 
 `$ source project_2000680-openrc.sh`
 
@@ -93,7 +93,7 @@ Only perform this step once you are happy with the "pre-prod" instance created i
 
 To create an immediate backup from production:
 
- * Make sure the staging (`portal-pre-prod`) and production (`portal-prod`) IP addresses are correctly set in `inventories/openstack_portal_pre_prod`. 
+ * Make sure the staging (`portal-pre-prod`) and production (`portal-prod`) IP addresses are correctly set in `inventories/openstack_portal_pre_prod`.
  * Run ansible-playbook -i inventories/openstack_portal_pre_prod portalPouta.yml -t get_fresh_backup
 
 ## Prepare the pre-production (staging) server
@@ -130,13 +130,12 @@ This assumes that the pre-production server is otherwise ready.
 
 ## Switch to the new version
 
- - On pre-production run as root: 
+ - On pre-production run as root:
   -``sudo -u apache /usr/local/bin/wp config set WP_DEBUG false --raw --path=/var/www/html``
   - ``sudo -u apache /usr/local/bin/wp super-cache flush --path=/var/www/html``
  - Make sure the menu background is now black.
  - login to the proxy: ("kielipankki-proxy-prod": ssh cloud-user@195.148.30.210) 
  - change the proxy settings in /etc/httpd/conf.d/ssl.conf and point to the pre-production server's INTERNAL IP (7/2020 that is: 192.168.1.8). The new server is immediately in use and now considered production.
  - Important: RENAME the now production server manually in the cPouta dashboard from portal-pre-prod to portal-prod (or portal-prod2, if "portal-prod" is already in use. This prevents future ansible runs from changing the now renamed "portal-pre-prod".
- - 
+ -
 ansible-playbook -i inventories/openstack_static_production proxyPouta.yml -t apache_config_update
-

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ This assumes that the pre-production server is otherwise ready.
   -``sudo -u apache /usr/local/bin/wp config set WP_DEBUG false --raw --path=/var/www/html``
   - ``sudo -u apache /usr/local/bin/wp super-cache flush --path=/var/www/html``
  - Make sure the menu background is now black.
- - login to the proxy: ("kielipankki-proxy-prod": ssh cloud-user@195.148.30.210) 
- - change the proxy settings in /etc/httpd/conf.d/ssl.conf and point to the pre-production server's INTERNAL IP (7/2020 that is: 192.168.1.8). The new server is immediately in use and now considered production.
+ - login to the proxy: ("kielipankki-proxy-prod": ssh cloud-user@195.148.30.210)
+ - change the proxy settings in /etc/httpd/conf.d/kielipankki_vhost.conf and point to the pre-production server's INTERNAL IP (7/2020 that is: 192.168.1.8). The new server is immediately in use and now considered production.
  - Important: RENAME the now production server manually in the cPouta dashboard from portal-pre-prod to portal-prod (or portal-prod2, if "portal-prod" is already in use. This prevents future ansible runs from changing the now renamed "portal-pre-prod".
  -
 ansible-playbook -i inventories/openstack_static_production proxyPouta.yml -t apache_config_update

--- a/roles/wordpress/files/kielipankki/tyylit.css
+++ b/roles/wordpress/files/kielipankki/tyylit.css
@@ -1198,3 +1198,15 @@ table.tool_list .column-6 {
 }
 
 .close:hover { background: #00d9ff; }
+
+
+/* LBR response templates */
+
+.lbr-message-template {
+    background-color: var(--wp--preset--color--pale-pink);
+    padding: 1.25em 2.375em;
+}
+
+.lbr-message-template > p:last-child {
+    margin-bottom: 0;
+}

--- a/roles/wordpress/files/kielipankki/tyylit.css
+++ b/roles/wordpress/files/kielipankki/tyylit.css
@@ -35,11 +35,11 @@ body {
 	font-weight: normal;
 	letter-spacing: 0px;
 	line-height: 1.35em;
-	color: #282828;	
+	color: #282828;
 	font-family:'Lato', sans-serif;
 }
 
-/* Disable all comment links*/                                                 
+/* Disable all comment links*/
 i.fa-comments-o {
     display:none;
 }
@@ -82,7 +82,7 @@ i.fa-comments-o {
 	position: relative;
 	display: block;
 }
-	
+
 .page-nav ul {
 	display: none;
 }
@@ -135,11 +135,11 @@ i.fa-comments-o {
 	left: 0;
 	z-index: 100;
 }
-	
+
 .mobile-nav-dropdown li {
 	text-align: center;
 }
-	   
+
 .mobile-nav-dropdown a {
 	font-size: 16px;
 	color: #282828;
@@ -152,7 +152,7 @@ i.fa-comments-o {
 }
 
 .mobile-nav-dropdown a:hover,
-.mobile-nav-dropdown .active a, 
+.mobile-nav-dropdown .active a,
 .mobile-nav-dropdown .current-menu-item a {
 	color: #282828;
 }
@@ -194,13 +194,13 @@ i.fa-comments-o {
 	text-align:justify;
 }
 
-.leftcol h1, 
-.leftcol h2, 
-.leftcol h3, 
+.leftcol h1,
+.leftcol h2,
+.leftcol h3,
 .leftcol h4,
-.onecol h1, 
-.onecol h2, 
-.onecol h3, 
+.onecol h1,
+.onecol h2,
+.onecol h3,
 .onecol h4 {
 	color:#000000;
 	font-style:normal;
@@ -210,13 +210,13 @@ i.fa-comments-o {
 	text-align: left;
 }
 
-.leftcol h1.first, 
-.leftcol h2.first, 
-.leftcol h3.first, 
+.leftcol h1.first,
+.leftcol h2.first,
+.leftcol h3.first,
 .leftcol h4.first,
-.onecol h1.first, 
-.onecol h2.first, 
-.onecol h3.first, 
+.onecol h1.first,
+.onecol h2.first,
+.onecol h3.first,
 .onecol h4.first {
 	margin-top: 0em;
 }
@@ -321,8 +321,8 @@ th.other_information, td.other_information {
 }
 
 
-.leftcol blockquote, 
-.leftcol em, 
+.leftcol blockquote,
+.leftcol em,
 .leftcol cite {
 	font-style: italic;
 }
@@ -416,9 +416,9 @@ th.other_information, td.other_information {
 	font-size: 0.9em;
 	margin-top: -1.25em;
 	margin-bottom: -0.5em;
-	padding: 0% 0%; 
+	padding: 0% 0%;
 	list-style-position: inside;
-	list-style-type: none; 
+	list-style-type: none;
 }
 
 .rightcol li.tribe-events-list-widget-events {
@@ -458,7 +458,7 @@ th.other_information, td.other_information {
 }
 
 .onecol table thead {
-	font-weight: 600; 
+	font-weight: 600;
 	background-color: rgba(0,0,0,0.1);
 }
 
@@ -466,8 +466,8 @@ th.other_information, td.other_information {
 	vertical-align: text-top;
 }
 
-.onecol blockquote, 
-.onecol em, 
+.onecol blockquote,
+.onecol em,
 .onecol cite {
 	font-style: italic;
 }
@@ -501,7 +501,7 @@ th.other_information, td.other_information {
 .onecol pre.light,
 .leftcol p.light,
 .leftcol pre.light  {
-        white-space: pre-wrap; 
+        white-space: pre-wrap;
         hyphens: none;
 	background-color: #DCE3F0;
 }
@@ -538,7 +538,7 @@ th.other_information, td.other_information {
 	text-decoration:none;
 }
 
-.leftcol p a:hover, 
+.leftcol p a:hover,
 .leftcol p a:active {
 	text-decoration:underline;
 }
@@ -584,7 +584,7 @@ th.other_information, td.other_information {
 	text-decoration:none;
 }
 
-.lightbox li a:hover, 
+.lightbox li a:hover,
 .lightbox a:hover {
 	text-decoration:underline;
 }
@@ -775,26 +775,26 @@ p.infoicon a {
 }
 
 @media only screen and (min-width: 800px) {
-	
+
 	/* Navigation */
 
 	.page-nav {
 		display: table;
 	}
-	 
+
 	.page-nav ul {
 		max-width: 960px;
 		margin: 0 auto;
 		display: table-row;
 	}
-	 
+
 	.page-nav li {
 		margin: 0;
 		padding: 0;
 		text-align: center;
 		display: table-cell;
 	}
-	 
+
 	.page-nav a {
 		font-family: inherit;
 		font-size: 18px;
@@ -807,17 +807,17 @@ p.infoicon a {
 		position: relative;
 		margin: 0px 8px;
 	}
-	
+
 	.page-nav li.lang a {
 		margin-left: 3em;
 		color:#7A90C3;
 	}
-	
+
     .page-nav li.lang2 a{
 		margin-left: 1em;
 		color:#7A90C3;
 	}
-	
+
 	.page-nav a:hover,
 	.page-nav .active a,
 	.page-nav .current-menu-item a {
@@ -882,26 +882,26 @@ p.infoicon a {
 		padding-left:5%;
 		padding-right:5%;
 	}
-	
+
 	.leftcol {
 		margin-bottom: 3em;
 		width:100%;
 		float:none;
 		clear:both;
 	}
-	
+
 	.rightcol {
 		width:100%;
 		float:none;
 		clear:both;
 	}
-	
+
 	.footer {
 		height: auto;
 		padding-top:18px;
 		padding-bottom: 18px;
 	}
-	
+
 	.footer .copyright,
 	.footer .footerlinks {
 		float:none;
@@ -911,9 +911,9 @@ p.infoicon a {
 		padding-right: 10%;
 		text-align: center;
 	}
-	
+
 	/* navi */
-	
+
 	.nav-wrapper {
 		height: auto;
 		min-height: 60px;
@@ -922,18 +922,18 @@ p.infoicon a {
 		margin: 0 auto;
 		padding: 10px;
 	}
-	
+
 	.page-nav ul.opened {
 		display:block;
 	}
-	
+
 	.page-nav li {
 		margin: 0;
 		padding: 0;
 		text-align: center;
 		display: block;
 	}
-	
+
 	.page-nav a {
 		font-family: inherit;
 		font-size: 16px;
@@ -946,11 +946,11 @@ p.infoicon a {
 		margin: 0px 5px;
 		color: #F16522;
 	}
-	
+
 	.page-nav a.lang {
 		color:#7A90C3;
 	}
-	
+
 	.page-nav a:hover,
 	.page-nav .active a {
 		color: #FFFFFF;
@@ -964,30 +964,30 @@ div.ccomme {
 /* NEW Styles for the corpus lists (upcoming, all languages) */
 
 table.corpuslist_upcoming .column-1 {
-    vertical-align: middle;    
+    vertical-align: middle;
     width: 12%;
 }
 
 table.corpuslist_upcoming .column-2 {
-    vertical-align: middle;    
+    vertical-align: middle;
 }
 
 /* all other columns */
 
-table.corpuslist_upcoming .column-5, 
-table.corpuslist_upcoming .column-7, 
+table.corpuslist_upcoming .column-5,
+table.corpuslist_upcoming .column-7,
 table.corpuslist_upcoming .column-8 {
     text-align: center;
-    vertical-align: middle;    
+    vertical-align: middle;
     width: 4.5em;
 }
 
 table.corpuslist_upcoming .column-3 {
-    vertical-align: middle;    
+    vertical-align: middle;
     width: 5.5em;
 }
 
-table.corpuslist_upcoming .column-4 { 
+table.corpuslist_upcoming .column-4 {
     text-align: center;
     vertical-align: middle;
     width: 4.5em;
@@ -1001,7 +1001,7 @@ table.corpuslist_upcoming .column-7 {
     width: 6em;
 }
 
-table.corpuslist_upcoming .column-8, 
+table.corpuslist_upcoming .column-8,
 table.corpuslist_upcoming .column-9 {
     text-align: center;
     vertical-align: middle;
@@ -1029,43 +1029,43 @@ table.corpuslist_upcoming .column-14 {
 /* NEW Styles for the corpus lists (production, all languages) */
 
 table.corpuslist2 .column-1 {
-    vertical-align: middle;    
+    vertical-align: middle;
     width: 12%;
 }
 
 table.corpuslist2 .column-2 {
-    vertical-align: middle;    
+    vertical-align: middle;
 }
 
 /* all other columns */
 table.corpuslist2 .column-4,
-table.corpuslist2 .column-7, 
+table.corpuslist2 .column-7,
 table.corpuslist2 .column-8 {
     text-align: center;
-    vertical-align: middle;    
+    vertical-align: middle;
     width: 4.5em;
 }
 
 table.corpuslist2 .column-3 {
-    vertical-align: middle;    
+    vertical-align: middle;
     width: 6em;
-} 
+}
 
 table.corpuslist2 .column-5 {
-    vertical-align: middle;    
+    vertical-align: middle;
     width: 5em;
 }
- 
+
 table.corpuslist2 .column-6 {
     width: 5em;
 }
 
-table.corpuslist2 .column-6, 
-table.corpuslist2 .column-7, 
-table.corpuslist2 .column-8, 
-table.corpuslist2 .column-9, 
-table.corpuslist2 .column-10, 
-table.corpuslist2 .column-11, 
+table.corpuslist2 .column-6,
+table.corpuslist2 .column-7,
+table.corpuslist2 .column-8,
+table.corpuslist2 .column-9,
+table.corpuslist2 .column-10,
+table.corpuslist2 .column-11,
 table.corpuslist2 .column-12,
 table.corpuslist2 .column-13,
 table.corpuslist2 .column-14 {
@@ -1108,37 +1108,37 @@ table.rotma .column-4 {
 /* Tools */
 
 table.tool_list .column-1 {
-    vertical-align: middle;    
+    vertical-align: middle;
     width: 19%;
 }
 
 table.tool_list .column-2 {
-    vertical-align: middle;    
+    vertical-align: middle;
     width: 19%;
 }
 
 
 
 table.tool_list .column-3 {
-    vertical-align: middle;    
+    vertical-align: middle;
     width: 28%;
-} 
+}
 
 table.tool_list .column-4 {
     text-align: center;
-    vertical-align: middle;    
+    vertical-align: middle;
     width: 12%;
 }
 
 table.tool_list .column-5 {
     text-align: center;
-    vertical-align: middle;    
+    vertical-align: middle;
     width: 10%;
 }
 
 table.tool_list .column-6 {
     text-align: center;
-    vertical-align: middle;    
+    vertical-align: middle;
     width: 12%;
 }
 


### PR DESCRIPTION
Previously we have used wordpress-builtins `has-pale-pink-backgroud-color` and `has-background` for otherwise normal `p` elements. This causes problems though: multi-paragraph messages each have their own background box. Even if those classes were applied to a container `div` or such, the spacing becomes wonky, as the margins and paddings defined for `p` and `has-backgorund` elements together cause a really big empty area at the bottom of the message template box.

This is fixed by creating a separate class for this specific use. The background colour is kept as is, but the empty space around the content is now created by the container element, meaning that the `p`-elements within don't need to have classes of their own. This will hopefully also make the page more likely to not break when edited with the visual editor.

The double margin/padding is prevented by removing the bottom margin from the last `p` in the message container.

As a side gig, updated the proxy configuration file in README, as it pointed to the wrong file.

My editor also trimmed the trailing whitespaces from the edited files. Sori siitä. But at least it's in a different commit.