### PR TITLE
KP-8616 remove unused comment section that causes PHP error

### DIFF
--- a/roles/wordpress/files/kielipankki/license.php
+++ b/roles/wordpress/files/kielipankki/license.php
@@ -542,9 +542,6 @@ if ( have_posts() ) {
 	} // end while
 } // end if
 	?>
-	<div class="ccomme">
-	<?php comments_template(); ?> 
-	</div>
 </div>
 </div>    
 <?php


### PR DESCRIPTION
Using /var/log/php-fhm/www-error.log I found out that the error occurs in the "comment section" which is not used here at all. It was likely copy/pasted and never created an error before. Removing that code fixed the issue without affecting the page otherwise.