### PR TITLE
Kp 8837 portal update

### DIFF
--- a/inventories/development
+++ b/inventories/development
@@ -2,12 +2,12 @@ all:
   hosts:
     localhost:
       ansible_connection: local
-      floating_ip: 195.148.21.204
+      floating_ip: 86.50.170.142
       vm_name_postfix: pre-prod
       ansible_python_interpreter: python
     portal:
-      ansible_host: 195.148.21.204
+      ansible_host: 86.50.170.142
       ansible_user: almalinux
     portal-prod:
-      ansible_host: 128.214.255.125
-      ansible_user: cloud-user
+      ansible_host: 195.148.21.204
+      ansible_user: almalinux

--- a/inventories/production
+++ b/inventories/production
@@ -2,9 +2,9 @@ all:
   hosts:
     localhost:
       ansible_connection: local
-      floating_ip: 128.214.255.125
+      floating_ip: 195.148.21.204
       vm_name_postfix: pre-prod
       ansible_python_interpreter: python
     portal:
-      ansible_host: 128.214.255.125
+      ansible_host: 195.148.21.204
       ansible_user: almalinux

--- a/roles/mariadb/tasks/install.yml
+++ b/roles/mariadb/tasks/install.yml
@@ -5,7 +5,7 @@
   yum_repository:
     name: MariaDB
     description: MariaDB Database repo
-    baseurl: https://mirror.mariadb.org/yum/11.4.1/almalinux9-amd64/
+    baseurl: https://mirror.mariadb.org/yum/11.4/almalinux9-amd64/
     gpgkey: https://mirror.mariadb.org/yum/RPM-GPG-KEY-MariaDB
     gpgcheck: true
 


### PR DESCRIPTION
This was a maintenance update., updating the OS, Wordpress+plugins.
- IPs had changed and could not be reclaimed, so new IPs are assigned to prod/pre-prod vms.
- The mariadb repo url is not correctly pointing to major.minor.