### PR TITLE
KP-9799 Tags for news/uutiset

### DIFF
--- a/roles/wordpress/files/kielipankki/functions.php
+++ b/roles/wordpress/files/kielipankki/functions.php
@@ -68,12 +68,12 @@ function create_post_type() {
   );
 
 /* what is this? -- mma 4.7.19
-$args = array( 
+$args = array(
       'hierarchical' => true,
       'labels' => $labels,
       'show_ui' => true,
       'show_admin_column' => true,
-      'query_var' => true, 
+      'query_var' => true,
       );
 
   //  register_taxonomy_for_object_type( 'category', 'uutiset' );
@@ -87,7 +87,7 @@ $args = array(
 function custom_theme_setup() {
 	add_theme_support( 'post-thumbnails', array( 'page', 'post', 'uutiset', 'news' ) );
 	add_theme_support( 'menus');
-	add_theme_support( 'html5', array( 'comment-list', 'comment-form', 'search-form', 'gallery', 'caption' ) );    
+	add_theme_support( 'html5', array( 'comment-list', 'comment-form', 'search-form', 'gallery', 'caption' ) );
 
 	register_sidebar( array(
         'name' => __( 'Default Sidebar Fin', '' ),
@@ -106,7 +106,7 @@ function custom_theme_setup() {
 	'after_widget'  => '',
 	'before_title'  => '<div>',
 	'after_title'   => '</div>',
-    ) ); 
+    ) );
 	register_sidebar( array(
         'name' => __( 'Default Sidebar Swe', '' ),
         'id' => 'sidebar-1-swe',
@@ -115,7 +115,7 @@ function custom_theme_setup() {
 	'after_widget'  => '',
 	'before_title'  => '<div>',
 	'after_title'   => '</div>',
-    ) ); 
+    ) );
 
     	register_sidebar( array(
         'name' => __( 'Footer Fin', '' ),
@@ -162,7 +162,7 @@ function custom_theme_setup() {
 	'after_widget'  => '',
 	'before_title'  => '<div>',
 	'after_title'   => '</div>',
-    ) ); 
+    ) );
 
 	register_sidebar( array(
         'name' => __( '404 Sidebar Fin', '' ),
@@ -193,9 +193,9 @@ function custom_theme_setup() {
     ) );
 }
 
-function wpb_list_child_pages() { 
+function wpb_list_child_pages() {
 
-global $post; 
+global $post;
 
 if ( is_page() && $post->post_parent )
 

--- a/roles/wordpress/files/kielipankki/functions.php
+++ b/roles/wordpress/files/kielipankki/functions.php
@@ -46,7 +46,7 @@ function create_post_type() {
       'has_archive' => true,
 	  'menu_position' => 5,
 	  'menu_icon' => 'dashicons-media-text',
-	  'taxonomies' => array('category'),
+	  'taxonomies' => array('category', 'post_tag'),
 	  'supports' => array('title', 'editor', 'thumbnail', 'excerpt', 'revisions' )
     )
   );
@@ -62,7 +62,7 @@ function create_post_type() {
       'has_archive' => true,
 	  'menu_position' => 6,
 	  'menu_icon' => 'dashicons-media-text',
-	  'taxonomies' => array('category'),
+	  'taxonomies' => array('category', 'post_tag'),
 	  'supports' => array('title', 'editor', 'thumbnail', 'excerpt', 'revisions' )
     )
   );


### PR DESCRIPTION
We do news using two custom post categories (one for each language variant), and by default, they don't support tags. This PR adds tag support for both of the post types, making the tag selection tool appear in the edit mode.

These posts can be viewed by tag by visiting urls such as https://www.kielipankki.fi/aihetunniste/demo-tag/. **NB:** the vanilla behaviour is that different types of content (events vs "uutiset" vs "news" etc) must be searched separately, meaning that assigning a couple of events, uutiset and news items to tag `demo-tag` will mean that visiting...
- https://www.kielipankki.fi/aihetunniste/demo-tag only shows the events
- https://www.kielipankki.fi/aihetunniste/demo-tag?post_type=uutiset shows events and Finnish news
- https://www.kielipankki.fi/aihetunniste/demo-tag?post_type=news shows events and English news
This could be a gift or a curse.