### PR TITLE
KP-9656 change citation date source, add forthcoming

### DIFF
--- a/roles/wordpress/files/kielipankki/popup.php
+++ b/roles/wordpress/files/kielipankki/popup.php
@@ -63,10 +63,10 @@ function get_corpus($mysqli, $input) {
 function localize($lang,$key) {
     static $l18n = array(
 	"fi" => array(
-	    "data set" => "korpus", /* generic */
+	    "data set" => "aineisto", /* generic */
 	    "ref_heading" => "Viittausohje",
 	    "ref_intro" => "Viittaa kielivaraan näin:",
-	    "bibtex_intro_text" => "Kopioi koodi alla bibtex-kirjastoosi. Koodi on testattu apacite.sty-tyyillä. Kenttä <code>url</code> ei toimi kaikilla bibtex-tyylillä, kokeile silloin <code>note</code>-kenttää <code>url</code>:n sijaan.",
+	    "bibtex_intro_text" => "Kopioi koodi alla bibtex-kirjastoosi. Koodi on testattu apacite.sty-tyylillä. Kenttä <code>url</code> ei toimi kaikilla bibtex-tyyleillä, kokeile silloin <code>note</code>-kenttää <code>url</code>:n sijaan.",
 	    "zotero_intro_text" => "Kopioi koodi alla leikepöydälle. Luo Zoterossa 'Report'-tietueen valitsemalla 'Actions > Import from clipboard'. Zoteron 'Report'-tietue on parhaiten yhteensopiva tyyli.",
 	    "show" => "Näytä: ",
 	    "search_scholar" => "Etsi viittauksia aineistoon Google Scholar -palvelusta.",

--- a/roles/wordpress/files/kielipankki/popup.php
+++ b/roles/wordpress/files/kielipankki/popup.php
@@ -102,29 +102,29 @@ function localize($lang,$key) {
 /*
    Renders author(s) and date. A missing author will not render a date
  */
-function render_author_date($lang, $row) {
+function render_author_year($lang, $row) {
     $authors=get_authors($lang ,$row);
-    $date=render_date($lang, $row);
-    $author_date="";
+    $year=render_year($lang, $row);
+    $author_year="";
     $author_count=count($authors);
     if ($authors) {
 	/* For one author, just return the rendered author. Otherwise separate with commas and add & for the last entry. */
 	if ($author_count == 1) {
-	    $author_date .= render_author($authors[0]);
+	    $author_year .= render_author($authors[0]);
 	} else {
 	    /* list the authors, put an & in front of the last.*/
 	    for ($i = 0; $i < $author_count-1 ; $i++) {
-		$author_date .= render_author($authors[$i]).", ";
+		$author_year .= render_author($authors[$i]).", ";
 	    }
-	    $author_date .= "&amp; " . render_author($authors[$author_count-1]);
+	    $author_year .= "&amp; " . render_author($authors[$author_count-1]);
 	}
 	/* Add date if known */
-	if ($date) {
-	    $author_date.=$date;
+	if ($year) {
+	    $author_year.=$year;
 	}
-	$author_date .= ". ";
+	$author_year .= ". ";
     }
-    return $author_date;
+    return $author_year;
 }
 
 /* render the author.
@@ -182,23 +182,26 @@ function get_authors($lang, $row) {
    Render the date as (date).
  */
 
-function render_date($lang, $row) {
-    $date=get_date($row, $lang);
-    if ($date) {
-	$date_parts=explode("-", $date);
-	return " (".$date_parts[0].")";
+function render_year($lang, $row) {
+    $year=get_year($lang, $row);
+    if ($year) {
+	return "(".$year.")";
     } else {
 	return "";
     }
 }
 
-function get_date($row, $lang) {
-    $date = $row['language_bank_publication_date'];
+function get_year($lang, $row) {
     $corpus_status = $row['corpus_status'];
     if ($corpus_status == "upcoming") {
       return localize($lang, "forthcoming");
+    }
+    $date = $row['language_bank_publication_date'];
+    if ($date) {
+	$date_parts=explode("-", $date);
+	return "$date_parts[0]";
     } else {
-      return $date;
+	return "";
     }
 }
 
@@ -274,7 +277,7 @@ function get_urn($row) {
  */
 
 function render_reference($lang,$row) {
-    return render_author_date($lang,$row) .
+    return render_author_year($lang,$row) .
            render_title($lang, $row) . " " .
            render_type($lang, $row) . ". ".get_publisher(). ". " .
            render_urn($lang,$row) ;
@@ -289,8 +292,8 @@ function render_bibtex($lang,$row, $key) {
     $bibtex="";
     $author_list = get_authors($lang,$row);
     if ($author_list) $authors = str_replace("  "," ",implode(" and ", $author_list));
-    $year   = get_date($row, $lang);
-    $type   = get_type($lang,$row);
+    $year   = get_year($lang, $row);
+    $type   = get_type($lang, $row);
     $bibtex .= "@misc{".get_shortname($row)."_".$lang.",\n";
     if ($authors) {
 	$authors = str_replace("_"," ",$authors);
@@ -315,8 +318,8 @@ function render_zotero($lang,$row, $key) {
     $bibtex="";
     $author_list = get_authors($lang,$row);
     if ($author_list) $authors = str_replace("  "," ",implode(" and ", $author_list));
-    $year   = get_date($row, $lang);
-    $type   = get_type($lang,$row);
+    $year   = get_year($lang, $row);
+    $type   = get_type($lang, $row);
     $bibtex .= "@techreport{".get_shortname($row)."_".$lang.",\n";
     if ($authors) {
 	$authors = str_replace("_"," ",$authors);

--- a/roles/wordpress/files/kielipankki/popup.php
+++ b/roles/wordpress/files/kielipankki/popup.php
@@ -64,7 +64,6 @@ function localize($lang,$key) {
     static $l18n = array(
 	"fi" => array(
 	    "data set" => "korpus", /* generic */
-	    "available_at" => "Saatavilla",
 	    "ref_heading" => "Viittausohje",
 	    "ref_intro" => "Viittaa kielivaraan näin:",
 	    "bibtex_intro_text" => "Kopioi koodi alla bibtex-kirjastoosi. Koodi on testattu apacite.sty-tyyillä. Kenttä <code>url</code> ei toimi kaikilla bibtex-tyylillä, kokeile silloin <code>note</code>-kenttää <code>url</code>:n sijaan.",
@@ -79,7 +78,6 @@ function localize($lang,$key) {
 	    "data set" => "data set", /* generic */
 	    "ref_heading" => "Reference instructions",
 	    "ref_intro" => "Please cite the language resource as follows:",
-	    "available_at" => "Retrieved from",
 	    "bibtex_intro_text" => "Copy the code below to your bibtex bibliography file. The code has been tested using the style apacite.sty. The field <code>url</code> does not work in all styles. In case of problems try changing it to <code>note</code> instead.",
 	    "zotero_intro_text" => "Copy the code below to the clipboard. In Zotero, create a 'Report' item by clicking 'Actions > Import from clipboard'. Zotero's 'Report' item is the most compatible style.",
 	    "show" => "Show: ",
@@ -279,7 +277,7 @@ function render_reference($lang,$row) {
     return render_author_date($lang,$row) .
            render_title($lang, $row) . " " .
            render_type($lang, $row) . ". ".get_publisher(). ". " .
-           localize($lang,"available_at")." ".render_urn($lang,$row) ;
+           render_urn($lang,$row) ;
 }
 
 /*

--- a/roles/wordpress/files/kielipankki/popup.php
+++ b/roles/wordpress/files/kielipankki/popup.php
@@ -73,6 +73,7 @@ function localize($lang,$key) {
 	    "search_scholar" => "Etsi viittauksia aineistoon Google Scholar -palvelusta.",
 	    "not_found" => "ei löytynyt",
 	    "lb_notified" => "Ilmoitus on lähetetty Kielipankin ylläpidolle.",
+	    "forthcoming" => "tulossa"
 	),
 	"en" => array(
 	    "data set" => "data set", /* generic */
@@ -85,6 +86,7 @@ function localize($lang,$key) {
 	    "search_scholar" => "Search for references to the language resource in Google Scholar",
 	    "not_found" => "not found",
 	    "lb_notified" => "The Language Bank administrators will be notified.",
+	    "forthcoming" => "forthcoming",
 	)
     );
 
@@ -103,8 +105,8 @@ function localize($lang,$key) {
    Renders author(s) and date. A missing author will not render a date
  */
 function render_author_date($lang, $row) {
-    $authors=get_authors($lang,$row);
-    $date=render_date($row);
+    $authors=get_authors($lang ,$row);
+    $date=render_date($lang, $row);
     $author_date="";
     $author_count=count($authors);
     if ($authors) {
@@ -182,8 +184,8 @@ function get_authors($lang, $row) {
    Render the date as (date).
  */
 
-function render_date($row) {
-    $date=get_date($row);
+function render_date($lang, $row) {
+    $date=get_date($row, $lang);
     if ($date) {
 	$date_parts=explode("-", $date);
 	return " (".$date_parts[0].")";
@@ -192,8 +194,14 @@ function render_date($row) {
     }
 }
 
-function get_date($row) {
-    return $row['first_publication_date'];
+function get_date($row, $lang) {
+    $date = $row['language_bank_publication_date'];
+    $corpus_status = $row['corpus_status'];
+    if ($corpus_status == "upcoming") {
+      return localize($lang, "forthcoming");
+    } else {
+      return $date;
+    }
 }
 
 /*
@@ -283,7 +291,7 @@ function render_bibtex($lang,$row, $key) {
     $bibtex="";
     $author_list = get_authors($lang,$row);
     if ($author_list) $authors = str_replace("  "," ",implode(" and ", $author_list));
-    $year   = get_date($row);
+    $year   = get_date($row, $lang);
     $type   = get_type($lang,$row);
     $bibtex .= "@misc{".get_shortname($row)."_".$lang.",\n";
     if ($authors) {
@@ -309,7 +317,7 @@ function render_zotero($lang,$row, $key) {
     $bibtex="";
     $author_list = get_authors($lang,$row);
     if ($author_list) $authors = str_replace("  "," ",implode(" and ", $author_list));
-    $year   = get_date($row);
+    $year   = get_date($row, $lang);
     $type   = get_type($lang,$row);
     $bibtex .= "@techreport{".get_shortname($row)."_".$lang.",\n";
     if ($authors) {
@@ -428,7 +436,7 @@ function render_zotero($lang,$row, $key) {
 		} // end while
 	    } // end if
 
-        if ($show_last_modified) {
+        if (isset($show_last_modified)) {
         make_last_modified($lang);
     }
 


### PR DESCRIPTION
This commit was tested in preproduction and contains the following fixes:
- use language_bank_publication_year as source for citation date
- render forthcoming/tulossa for upcoming resources
- make check for last modified more robust.
- additionally "Saatavilla/Retrieved at" was removed as discussed in PO meeting.