### PR TITLE
KP-9145 Make Portal provisionable again

### DIFF
--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -9,10 +9,13 @@
     name: firewalld
     state: absent
 
-- name: install iptables-services
+- name: install iptables
   yum:
-    name: iptables-services
+    name: "{{ item }}"
     state: present
+  loop:
+    - iptables-legacy
+    - iptables-services
 
 - name: copy IP4/6 firewall statup scripts (if not already present)
   template:

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -9,7 +9,7 @@
     name: firewalld
     state: absent
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7
-  
+
 - name: install iptables-services
   yum:
     name: iptables-services

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -9,13 +9,14 @@
     name: firewalld
     state: absent
 
-- name: install iptables
+- name: install packages required for iptables configuraion
   yum:
     name: "{{ item }}"
     state: present
   loop:
     - iptables-legacy
     - iptables-services
+    - initscripts-service
 
 - name: copy IP4/6 firewall statup scripts (if not already present)
   template:

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -8,13 +8,11 @@
   yum:
     name: firewalld
     state: absent
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7
 
 - name: install iptables-services
   yum:
     name: iptables-services
     state: present
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7
 
 - name: copy IP4/6 firewall statup scripts (if not already present)
   template:

--- a/roles/pid_generator/files/check_pids.py
+++ b/roles/pid_generator/files/check_pids.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import datetime
 import MySQLdb
 import sys

--- a/roles/pid_generator/files/gen_lat_pids.py
+++ b/roles/pid_generator/files/gen_lat_pids.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 from lxml import etree
 from lxml import objectify
 import datetime

--- a/roles/pid_generator/files/gen_pids.py
+++ b/roles/pid_generator/files/gen_pids.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 from lxml import etree
 from lxml import objectify
 import datetime


### PR DESCRIPTION
The currently available Pouta image is AlmaLinux 9.5, while the earlier production and preprod machines run on 9.4. This resulted in all kinds of small stuff that messed with our provisioning. This PR makes the provisioning work again but introduces no other changes.

TL;DR of the changes:
- install `iptables-legacy` (no longer there by default)
- install `initscripts-service` (provides `/sbin/service` which the firewall uses)
- explicitly use python3 in PID generator shebangs