### PR TITLE
KP-9145 Fix default condition merging bug

### DIFF
--- a/roles/wordpress/files/kielipankki/license.php
+++ b/roles/wordpress/files/kielipankki/license.php
@@ -359,7 +359,6 @@ switch ($lic_type) {
         } else {
             update_field('field_569388a5a6fe1', $id_access_default); // ID ACCESS
         }
-
         $usage_default=array('BY');
         $lic_usage = get_field('field_5693b54a4348c');
         if ($lic_usage) {


### PR DESCRIPTION
Earlier it could e.g. happen that you tick boxes ID and AFFIL=EDU for a RES resource, but the license page would show ID and PLAN. Similarly, if you ticked ID, AFFIL=EDU and PLAN, you would get ID, PLAN, PLAN.

This was due to use of the `+` operator for arrays, which is a "union", but PHP arrays are more like dicts and the union works with the keys of the array, which in our case are implicit indexing. This example and its output illustrate the behaviour:
```
$a=array('a', 'b');
$b=array('c', 'd');

print_r($a);
print_r($b);
print_r($a + $b);
```
```
Array
(
    [0] => a
    [1] => b
)
Array
(
    [0] => c
    [1] => d
)
Array
(
    [0] => a
    [1] => b
)
```

Now the behaviour has been fixed so that we do union of the values in the array, resulting in the desired behaviour.

NB: this implementation means that the order of the displayed elements can change. I think this also happened with the old implementation though. The tags won't reorder "on themselves" but depending on the manipulation of the list instead. If you for example:
1. Create a RES license with ID and PLAN selected in the identification and access conditions, save page and view it, you see them in order ID, PLAN.
2. Add AFFIL=EDU, save the form and f5 the page, you see ID, PLAN, AFFIL=EDU
3. Add FF and save&f5, you now see ID, AFFIL=EDU, FF, PLAN.
4. Remove FF and save&f5, you now see ID, AFFIL=EDU, PLAN (effectively same license as in step 2, but different order).

> [!warning]
> https://github.com/CSCfi/Kielipankki-portal-ansible/pull/24 must be merged first

This is a pre-requirement for https://github.com/CSCfi/Kielipankki-portal-ansible/pull/22