### PR TITLE
KP-8293 Restore backup from temporary file

### DIFF
--- a/roles/wordpress/tasks/restore_data.yml
+++ b/roles/wordpress/tasks/restore_data.yml
@@ -17,7 +17,7 @@
 
 - name: "Create fresh production backup"
   command: /usr/local/bin/backup.sh backup "{{ wp_db_install_password }}"
-  tags: [ 'never', 'get_fresh_backup']
+  tags: ['never', 'get_fresh_backup']
   delegate_to: portal-prod
 
 # workaround for issue with fetch, sudo + big files.
@@ -26,7 +26,7 @@
     path: "{{ item }}"
     mode: "o+rX"
   delegate_to: portal-prod
-  tags: [ 'never', 'get_fresh_backup']
+  tags: ['never', 'get_fresh_backup']
   loop:
     - "{{ backup_dir }}"
     - "{{ backup_dir }}/{{ dow }}-{{ backup_filename }}.gz"
@@ -36,9 +36,9 @@
     src: "{{ backup_dir }}/{{ dow }}-{{ backup_filename }}.gz"
     dest: "./"
     flat: yes
-  tags: [ 'never', 'get_fresh_backup']
+  tags: ['never', 'get_fresh_backup']
   delegate_to: portal-prod
-  become: no #otherwise it takes for ever.
+  become: no  # otherwise it takes for ever.
 
 # revert from above.
 - name: Remove read rights
@@ -46,7 +46,7 @@
     path: "{{ item }}"
     mode: "o-rwx"
   delegate_to: portal-prod
-  tags: [ 'never', 'get_fresh_backup']
+  tags: ['never', 'get_fresh_backup']
   loop:
     - "{{ backup_dir }}"
     - "{{ backup_dir }}/{{ dow }}-{{ backup_filename }}.gz"

--- a/roles/wordpress/tasks/restore_data.yml
+++ b/roles/wordpress/tasks/restore_data.yml
@@ -50,17 +50,22 @@
   loop:
     - "{{ backup_dir }}"
     - "{{ backup_dir }}/{{ dow }}-{{ backup_filename }}.gz"
-  
+
+- name: Create temporary file for uploading the backup file
+  ansible.builtin.tempfile:
+    state: file
+    prefix: backup_
+  register: backup_file
+  tags: update_wp_content
+
 - name: "Copy backup to host: {{ ansible_host }}"
   copy:
     src: "{{ dow }}-{{ backup_filename }}.gz"
-    dest: "{{ backup_dir }}"
-#  register: cp_wp_db
+    dest: "{{ backup_file.path }}"
   tags: update_wp_content
 
 - name: Apply backup
-  command: /usr/local/bin/backup.sh restore "{{ wp_db_install_password }}"
-#  no_log: true
+  command: /usr/local/bin/backup.sh restore "{{ wp_db_install_password }}" --restore-from "{{ backup_file.path }}"
   tags: update_wp_content
 
 - name: Update DB, Reactivate plugins, Flush cache


### PR DESCRIPTION
The old implementation copied the backup file to be restored on top of the today's backup file. This could lead to loss of important data e.g. if local backup file is from an earlier week or the IP addresses in the inventory are incorrect (overwriting production data with preprod data).

Now the backup is copied into a temporary file instead and restored from there (this requires changes from https://github.com/CSCfi/Kielipankki-ansible-common/pull/30), so there's no risk of losing the original backup files.