### PR TITLE
KP-11675 Increase PID generator timeout to 5 min

### DIFF
--- a/roles/pid_generator/templates/pid.conf.j2
+++ b/roles/pid_generator/templates/pid.conf.j2
@@ -5,4 +5,5 @@
    AllowOverride None
    Order allow,deny
    Allow from all
+   CGIDScriptTimeout 300
  </Directory>


### PR DESCRIPTION
This is not sufficient alone: proxy will timeout too. But at least this will prevent the timeout at portal side, which can be verified by adding a suitable `spleep` to the script and then curling from proxy:
```
[almalinux@kielipankki-proxy-pre-prod ~]$ curl http://192.168.1.148/pid/script/gen_pids.py

<pre>
INFO:root:URN update finished.
INFO:root:Handle update finished.

</pre>
```