### PR TITLE
KP-11199 Portal update

### DIFF
--- a/roles/mariadb/tasks/harden.yml
+++ b/roles/mariadb/tasks/harden.yml
@@ -18,7 +18,7 @@
 
 - name: Delete anonymous MySQL server user for current hostname
   mysql_user:
-    user: ""
+    name: ""
     host: "{{ ansible_hostname }}"
     state: absent
     login_user: root

--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -9,6 +9,13 @@
   async: 60
   poll: 0
 
+- name: Configure php.ini
+  lineinfile:
+    path: "/etc/php.ini"
+    regexp: "{{ item.parameter }} ="
+    line: "{{ item.parameter }} = {{ item.value }}"
+  loop: "{{ php_settings }}"
+
 - name: Is WordPress downloaded?
   stat: 
     path: "{{ wordpress_directory }}/index.php"
@@ -102,10 +109,3 @@
   args:
     chdir: "/var/www/html/wp-content/languages/"
   become_user: "{{ remote_deploy_user }}"
-
-- name: Configure php.ini
-  lineinfile:
-    path: "/etc/php.ini"
-    regexp: "{{ item.parameter }} ="
-    line: "{{ item.parameter }} = {{ item.value }}"
-  loop: "{{ php_settings }}"

--- a/roles/wordpress/tasks/install.yml
+++ b/roles/wordpress/tasks/install.yml
@@ -17,12 +17,12 @@
   loop: "{{ php_settings }}"
 
 - name: Is WordPress downloaded?
-  stat: 
+  stat:
     path: "{{ wordpress_directory }}/index.php"
   register: wp_dir
 
 - name: Create WordPress directory
-  file: 
+  file:
     path: "{{ wordpress_directory }}"
     owner: "{{ remote_deploy_user }}"
     group: "{{ remote_deploy_group }}"
@@ -84,7 +84,7 @@
            --path="{{ wordpress_directory }}"
   become_user: "{{ remote_deploy_user }}"
 
-  
+
 # Panel language
 - name: Install finnish language pack
   command: /usr/local/bin/wp language core install fi --activate


### PR DESCRIPTION
The main fix here is making sure that we increase PHP memory limit before installing WordPress: version 7.0 requires more memory to install than the default value is.

Additionally, there's [the mysql_user deprecation fix](https://github.com/CSCfi/Kielipankki-portal-ansible/commit/dc3faff3710126c8449dbb2ccb1fe7828b3e36fd) that we need unless we use totally ancient Ansible (this workds with 10.7.0 at least).